### PR TITLE
Return `self`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,6 @@ module.exports = self => {
 			self[key] = val.bind(self);
 		}
 	}
+
+	return self;
 };

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ message();
 
 ### autoBind(self)
 
-Bind methods in `self` to their class instance and returns the `self` object.
+Bind methods in `self` to their class instance. Returns the `self` object.
 
 #### self
 

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,19 @@ message();
 ```
 
 
+## API
+
+### autoBind(self)
+
+Bind methods in `self` to their class instance and returns the `self` object.
+
+#### self
+
+Type: `Object`
+
+Object with methods to bind.
+
+
 ## Related
 
 - [bind-methods](https://github.com/sindresorhus/bind-methods) - Bind all methods in an object to itself or a specified context

--- a/test.js
+++ b/test.js
@@ -2,10 +2,12 @@ import test from 'ava';
 import m from './';
 
 test(t => {
+	let bounded;
+
 	class Unicorn {
 		constructor(name) {
 			this.name = name;
-			m(this);
+			bounded = m(this);
 		}
 		message() {
 			return `${this.name} is awesome!`;
@@ -13,7 +15,8 @@ test(t => {
 	}
 
 	const unicorn = new Unicorn('Rainbow');
-	const message = unicorn.message;
+	t.is(bounded, unicorn);
 
+	const message = unicorn.message;
 	t.is(message(), 'Rainbow is awesome!');
 });


### PR DESCRIPTION
This would simplify some use cases, e.g. with [`pify`](https://github.com/sindresorhus/pify):

```js
class LegacyUnicorn {
    constructor(name) {
        this.name = name;
    }
    message(cb) {
        cb(null, `${this.name} is awesome!`);
    }
}

// instead of
let unicorn = new LegacyUnicorn('Rainbow');
autoBind(unicorn);
unicorn = pify(unicorn);

// we are able to
const unicorn = pify(autoBind(new LegacyUnicorn('Rainbow')));
```