### PR TITLE
Add support for symbol properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = (self, options) => {
 		return true;
 	};
 
-	for (const key of Object.getOwnPropertyNames(self.constructor.prototype)) {
+	const proto = self.constructor.prototype;
+	for (const key of Object.getOwnPropertyNames(proto).concat(Object.getOwnPropertySymbols(proto))) {
 		const value = self[key];
 
 		if (key !== 'constructor' && typeof value === 'function' && filter(key)) {

--- a/test.js
+++ b/test.js
@@ -98,7 +98,7 @@ test('autoBind.react()', t => {
 });
 
 test('symbol properties', t => {
-	const message = Symbol('message');
+	const messageSymbol = Symbol('message');
 
 	let bounded;
 
@@ -108,7 +108,7 @@ test('symbol properties', t => {
 			bounded = m(this);
 		}
 
-		[message]() {
+		[messageSymbol]() {
 			return `${this.name} is awesome!`;
 		}
 	}
@@ -116,6 +116,6 @@ test('symbol properties', t => {
 	const unicorn = new Unicorn('Rainbow');
 	t.is(bounded, unicorn);
 
-	const message = unicorn[message];
+	const message = unicorn[messageSymbol];
 	t.is(message(), 'Rainbow is awesome!');
 });

--- a/test.js
+++ b/test.js
@@ -97,3 +97,25 @@ test('autoBind.react()', t => {
 	t.is(foo(), 'Rainbow');
 });
 
+test('symbol properties', t => {
+	const message = Symbol('message');
+
+	let bounded;
+
+	class Unicorn {
+		constructor(name) {
+			this.name = name;
+			bounded = m(this);
+		}
+
+		[message]() {
+			return `${this.name} is awesome!`;
+		}
+	}
+
+	const unicorn = new Unicorn('Rainbow');
+	t.is(bounded, unicorn);
+
+	const message = unicorn[message];
+	t.is(message(), 'Rainbow is awesome!');
+});


### PR DESCRIPTION
Currently, prototype properties referenced by a `Symbol` are not bound to instances.  This is a 1.5-line hotfix to account for these properties by concatenating `Object.getOwnPropertySymbols()` to the list of keys that are bound.