### PR TITLE
Fix TypeScript definition for TypeScript 3.5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ declare const autoBind: {
 	//=> Error: Cannot read property 'name' of undefined
 	```
 	*/
-	<SelfType extends {[key: string]: unknown}>(
+	<SelfType extends {[key: string]: any}>(
 		self: SelfType,
 		options?: autoBind.Options
 	): SelfType;


### PR DESCRIPTION
One of the breaking changes (https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/#breaking-changes) included in Typescript 3.5 makes the library not usable with the current typescript definition. 

Specifically the point mentioning "`{ [k: string]: unknown }` is no longer a wildcard assignment target". A detail of the explanation is included in one of the section in the link above and multiple alternatives are listed at the end. In our case, replacing `unknown` by `any` seemed to be the most appropriate solution to make it compatible.