### PR TITLE
Remove react types from depedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
 		"react",
 		"component"
 	],
-	"dependencies": {
+	"peerDependencies": {
 		"@types/react": "^16.8.12"
 	},
 	"devDependencies": {
+		"@types/react": "^16.8.12",
 		"ava": "^1.4.1",
 		"tsd": "^0.7.3",
 		"xo": "^0.24.0"


### PR DESCRIPTION
Introduced when adding typescript support https://github.com/sindresorhus/auto-bind/pull/15/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R38

Adding `@types/react` to the `dependencies` is _great_. It allows users of the `ink` package to not worry about types. The react types are included automagically. However, having **multiple** `@types/react` in the dependency chain can cause havoc in a project, as `@types/react` tries to modify globals (specifically JSX globals). `tsc` will fail, noting that there are multiple declarations of X, Y and Z, where these are all the globals that are modified.

Having multiple `@types/react` in the chain happens for example when hoisting, when using workspaces, when using monorepos etc. Additionally, a user _should_ be able to provide their own `@types/react` version independent of this package, plus `auto-bind` does NOT depend on `react` directly, so it should NOT depend on the type definitions for a specific version either.

A possible solution is to make this a peer dependency: it won't be provided by the `auto-bind` library unless it's not present.

----

Note that in npm@3, it's likely that `peerDependencies` won't be automatically installed as they themselves can cause dependency hell. In this case, since typescript usage is optional, I would recommend adding this as an optional dependency.