### PR TITLE
Making sure auto-bind works for non class modules too

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ module.exports = (self, {include, exclude} = {}) => {
 
 		return true;
 	};
-
-	for (const [object, key] of getAllProperties(self.constructor.prototype)) {
+	const objectToLookInto = self.constructor.name !== 'Object' && self.constructor.name !== 'Function' ? self.constructor.prototype : self;
+	for (const [object, key] of getAllProperties(objectToLookInto)) {
 		if (key === 'constructor' || !filter(key)) {
 			continue;
 		}


### PR DESCRIPTION
The reason for this change is so that we're able to also bind es5 modules except from es6 classes.

Example:

```js
const anInstance = new MyClass();
autoBind(anInstance); // works
```
^ works

```js
module.exports = autoBind({
    hasSetup: true,
    setup() {
        // do sth cool
    }
});
```
^doesn't work